### PR TITLE
[Feature] 유저 카카오 로그인 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### yml ###
+application-dev.yml
+application-oauth.yml
+application-jwt.yml

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,23 @@ repositories {
 }
 
 dependencies {
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // OAuth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+    // ETC.
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/project/doblog/api/user/AuthController.java
+++ b/src/main/java/project/doblog/api/user/AuthController.java
@@ -1,0 +1,44 @@
+package project.doblog.api.user;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import project.doblog.application.user.AuthService;
+import project.doblog.infra.resolver.refresh.RefreshToken;
+import project.doblog.infra.security.jwt.token.TokenResponse;
+import project.doblog.utils.ServletUtils;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * 카카오 로그인 API
+     */
+    @PostMapping("/login/kakao")
+    public ResponseEntity<Void> loginKakao(@RequestParam(name = "code") String code) throws JsonProcessingException {
+        TokenResponse tokenResponse = authService.kakaoLogin(code);
+        addTokensToResponse(tokenResponse);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    /**
+     * JWT 토큰 재발급 API
+     */
+    @GetMapping("/reissue")
+    public ResponseEntity<Void> reissueToken(@RefreshToken String refreshToken) {
+        TokenResponse tokenResponse = authService.reissueAccessToken(refreshToken);
+        addTokensToResponse(tokenResponse);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    private void addTokensToResponse(TokenResponse tokenResponse) {
+        ServletUtils.addAuthorizationHeaderToResponse(tokenResponse.getAccessToken());
+        ServletUtils.addRefreshTokenCookieToResponse(tokenResponse.getRefreshToken());
+    }
+}

--- a/src/main/java/project/doblog/api/user/UserController.java
+++ b/src/main/java/project/doblog/api/user/UserController.java
@@ -1,0 +1,19 @@
+package project.doblog.api.user;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import project.doblog.infra.resolver.auth.Auth;
+import project.doblog.infra.resolver.refresh.RefreshToken;
+
+@RestController
+@RequestMapping("/v1/user")
+public class UserController {
+
+    @GetMapping
+    public String getUser(@Auth Long userId, @RefreshToken String refreshToken) {
+        System.out.println("userId = " + userId);
+        System.out.println("refreshToken = " + refreshToken);
+        return "user";
+    }
+}

--- a/src/main/java/project/doblog/application/user/AuthService.java
+++ b/src/main/java/project/doblog/application/user/AuthService.java
@@ -1,0 +1,187 @@
+package project.doblog.application.user;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import project.doblog.domain.user.User;
+import project.doblog.domain.user.repository.RefreshTokenRedisRepository;
+import project.doblog.domain.user.repository.UserRepository;
+import project.doblog.exception.error.InvalidTokenException;
+import project.doblog.exception.error.UserInfoRetrievalException;
+import project.doblog.exception.error.UserNotFoundException;
+import project.doblog.infra.security.jwt.token.RefreshToken;
+import project.doblog.infra.security.jwt.token.TokenProvider;
+import project.doblog.infra.security.jwt.token.TokenResponse;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final String DEFAULT_ROLE = "ROLE_USER";
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String kakaoClientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirect_uri;
+
+    @Transactional
+    public TokenResponse kakaoLogin(final String code) throws JsonProcessingException {
+        String token = getToken(code);
+        Map<String, String> userInfo = getKakaoUserInfo(token);
+        User user = saveIfNonExist(userInfo.get("email"), userInfo.get("profileImage"));
+
+        TokenResponse tokenResponse = tokenProvider.createToken(String.valueOf(user.getId()), user.getEmail(), DEFAULT_ROLE);
+
+        log.info("user = {} | New AccessToken = {}", user.getId(), tokenResponse.getAccessToken());
+        log.info("user = {} | New RefreshToken = {}", user.getId(), tokenResponse.getRefreshToken());
+
+        saveRefreshTokenOnRedis(user, tokenResponse);
+
+        return tokenResponse;
+    }
+
+    /**
+     * 로그인 성공 시 RefreshToken을 Redis에 저장
+     */
+    private void saveRefreshTokenOnRedis(final User user, final TokenResponse response) {
+        refreshTokenRedisRepository.save(RefreshToken.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .authorities(Collections.singleton(new SimpleGrantedAuthority(DEFAULT_ROLE)))
+                .refreshToken(response.getRefreshToken())
+                .build());
+    }
+
+    /**
+     * 카카오 AccessToken 발급
+     */
+    private String getToken(final String code) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", kakaoClientId);
+        body.add("client_secret", kakaoClientSecret);
+        body.add("redirect_uri", redirect_uri);
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> response;
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+            response = restTemplate.exchange(
+                    "https://kauth.kakao.com/oauth/token",
+                    HttpMethod.POST,
+                    kakaoTokenRequest,
+                    String.class
+            );
+        } catch (HttpClientErrorException e) {
+            throw new UserInfoRetrievalException();
+        }
+
+        String responseBody = response.getBody();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        return jsonNode.get("access_token").asText();
+    }
+
+    /**
+     * 카카오 사용자 정보 조회
+     */
+    private Map<String, String> getKakaoUserInfo(String token) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + token);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(headers);
+
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> response = restTemplate.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.POST,
+                    kakaoTokenRequest,
+                    String.class
+            );
+            String responseBody = response.getBody();
+            JsonNode jsonNode = objectMapper.readTree(responseBody);
+            String email = jsonNode.get("kakao_account").get("email").asText();
+            String profileImage = jsonNode.get("kakao_account").get("profile").get("profile_image_url").asText();
+
+            return Map.of("email", email, "profileImage", profileImage);
+        } catch (HttpClientErrorException e) {
+            throw new UserInfoRetrievalException();
+        }
+    }
+
+    @Transactional
+    public User saveIfNonExist(String email, String profileImage) {
+        return userRepository.findByEmail(email)
+                .orElseGet(() ->
+                        userRepository.save(
+                                User.createUser(email, "낯선 " + email.split("@")[0], profileImage)
+                        )
+                );
+    }
+
+    /**
+     * AccessToken, RefreshToken 재발급
+     */
+    public TokenResponse reissueAccessToken(String refreshToken) {
+
+        log.info("Current RefreshToken = {}", refreshToken);
+
+        // RefreshToken이 유효하지 않을 경우, 재로그인 필요
+        if (tokenProvider.isValid(refreshToken)) {
+            throw new InvalidTokenException();
+        }
+
+        RefreshToken findToken = Optional.ofNullable(refreshTokenRedisRepository.findByRefreshToken(refreshToken))
+                .orElseThrow(InvalidTokenException::new);
+        User findUser = userRepository.findByEmail(findToken.getEmail())
+                .orElseThrow(UserNotFoundException::new);
+
+        TokenResponse tokenResponse = tokenProvider.createToken(
+                String.valueOf(findToken.getId()),
+                findToken.getEmail(),
+                findToken.getAuthority());
+
+        saveRefreshTokenOnRedis(findUser, tokenResponse);
+        SecurityContextHolder.getContext().setAuthentication(tokenProvider.getAuthentication(tokenResponse.getAccessToken()));
+
+        log.info("user = {} | New AccessToken = {}", findUser.getId(), tokenResponse.getAccessToken());
+        log.info("user = {} | New RefreshToken = {}", findUser.getId(), tokenResponse.getRefreshToken());
+
+        return tokenResponse;
+    }
+}

--- a/src/main/java/project/doblog/config/SecurityConfig.java
+++ b/src/main/java/project/doblog/config/SecurityConfig.java
@@ -1,0 +1,61 @@
+package project.doblog.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import project.doblog.infra.security.jwt.JwtAccessDeniedHandler;
+import project.doblog.infra.security.jwt.JwtAuthenticationFailEntryPoint;
+import project.doblog.infra.security.jwt.JwtFilter;
+import project.doblog.infra.security.oauth.KakaoUserDetailsService;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+    private final JwtAuthenticationFailEntryPoint jwtAuthenticationFailEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final KakaoUserDetailsService kakaoUserDetailsService;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .oauth2Login(oauth -> {
+                    oauth.userInfoEndpoint(config -> config.userService(kakaoUserDetailsService));
+                })
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers("/v1/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(exceptionHandling -> {
+                    exceptionHandling.authenticationEntryPoint(jwtAuthenticationFailEntryPoint);
+                    exceptionHandling.accessDeniedHandler(jwtAccessDeniedHandler);
+                });
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/project/doblog/config/WebConfig.java
+++ b/src/main/java/project/doblog/config/WebConfig.java
@@ -1,0 +1,36 @@
+package project.doblog.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import project.doblog.infra.resolver.auth.AuthArgumentResolver;
+import project.doblog.infra.resolver.refresh.RefreshTokenArgumentResolver;
+
+import java.util.List;
+
+import static org.springframework.http.HttpMethod.*;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthArgumentResolver authArgumentResolver;
+    private final RefreshTokenArgumentResolver refreshTokenArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authArgumentResolver);
+        resolvers.add(refreshTokenArgumentResolver);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods(GET.name(), POST.name(), PUT.name(), PATCH.name(), DELETE.name(), OPTIONS.name())
+                .allowCredentials(true)
+                .exposedHeaders("*");
+    }
+}

--- a/src/main/java/project/doblog/domain/user/User.java
+++ b/src/main/java/project/doblog/domain/user/User.java
@@ -1,0 +1,43 @@
+package project.doblog.domain.user;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "user_email")
+    private String email;
+
+    @Column(name = "user_name")
+    private String name;
+
+    @Column(name = "user_profile_image")
+    private String profileImage;
+
+    @Builder
+    private User(String email, String name, String profileImage) {
+        this.email = email;
+        this.name = name;
+        this.profileImage = profileImage;
+    }
+
+    public static User createUser(String email, String name, String profileImage) {
+        return User.builder()
+                .email(email)
+                .name(name)
+                .profileImage(profileImage)
+                .build();
+    }
+}

--- a/src/main/java/project/doblog/domain/user/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/project/doblog/domain/user/repository/RefreshTokenRedisRepository.java
@@ -1,0 +1,9 @@
+package project.doblog.domain.user.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import project.doblog.infra.security.jwt.token.RefreshToken;
+
+public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
+
+    RefreshToken findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/project/doblog/domain/user/repository/UserRepository.java
+++ b/src/main/java/project/doblog/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package project.doblog.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import project.doblog.domain.user.User;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/project/doblog/exception/ErrorResponse.java
+++ b/src/main/java/project/doblog/exception/ErrorResponse.java
@@ -1,0 +1,23 @@
+package project.doblog.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * {
+ * "code": "400",
+ * "message": "잘못된 요청입니다."
+ * }
+ */
+@Getter
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+
+    @Builder
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/project/doblog/exception/ExceptionController.java
+++ b/src/main/java/project/doblog/exception/ExceptionController.java
@@ -1,0 +1,50 @@
+package project.doblog.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import project.doblog.exception.error.DoblogExcpetion;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionController {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> invalidRequestHandler(MethodArgumentNotValidException e) {
+        BindingResult result = e.getBindingResult();
+        String firstErrorMessage = result.getFieldErrors().get(0).getDefaultMessage();
+        List<String> errorList = result.getFieldErrors()
+                .stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.toList());
+
+        log.warn("검증 예외 리스트: {}", errorList);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.builder()
+                        .code(String.valueOf(HttpStatus.BAD_REQUEST.value()))
+                        .message(firstErrorMessage)
+                        .build());
+    }
+
+    @ExceptionHandler(DoblogExcpetion.class)
+    public ResponseEntity<ErrorResponse> doblogException(DoblogExcpetion e) {
+        log.warn("예외 메시지: {}", e.getMessage());
+
+        int statusCode = e.getStatusCode();
+
+        return ResponseEntity.status(statusCode)
+                .body(ErrorResponse.builder()
+                        .code(String.valueOf(statusCode))
+                        .message(e.getMessage())
+                        .build());
+    }
+}

--- a/src/main/java/project/doblog/exception/error/DoblogExcpetion.java
+++ b/src/main/java/project/doblog/exception/error/DoblogExcpetion.java
@@ -1,0 +1,13 @@
+package project.doblog.exception.error;
+
+import lombok.Getter;
+
+@Getter
+public abstract class DoblogExcpetion extends RuntimeException {
+
+    public DoblogExcpetion(String message) {
+        super(message);
+    }
+
+    public abstract int getStatusCode();
+}

--- a/src/main/java/project/doblog/exception/error/InvalidTokenException.java
+++ b/src/main/java/project/doblog/exception/error/InvalidTokenException.java
@@ -1,0 +1,15 @@
+package project.doblog.exception.error;
+
+public class InvalidTokenException extends DoblogExcpetion {
+
+    private static final String MESSAGE = "토큰이 만료되었거나 유효하지 않습니다.";
+
+    public InvalidTokenException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 401;
+    }
+}

--- a/src/main/java/project/doblog/exception/error/UserInfoRetrievalException.java
+++ b/src/main/java/project/doblog/exception/error/UserInfoRetrievalException.java
@@ -1,0 +1,15 @@
+package project.doblog.exception.error;
+
+public class UserInfoRetrievalException extends DoblogExcpetion {
+
+    private static final String MESSAGE = "사용자 정보를 가져오는데 실패했습니다.";
+
+    public UserInfoRetrievalException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 500;
+    }
+}

--- a/src/main/java/project/doblog/exception/error/UserNotFoundException.java
+++ b/src/main/java/project/doblog/exception/error/UserNotFoundException.java
@@ -1,0 +1,15 @@
+package project.doblog.exception.error;
+
+public class UserNotFoundException extends DoblogExcpetion {
+
+    private static final String MESSAGE = "존재하지 않는 사용자입니다.";
+
+    public UserNotFoundException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 404;
+    }
+}

--- a/src/main/java/project/doblog/infra/resolver/auth/Auth.java
+++ b/src/main/java/project/doblog/infra/resolver/auth/Auth.java
@@ -1,0 +1,14 @@
+package project.doblog.infra.resolver.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ *  사용자 인증 정보 추출 어노테이션
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/project/doblog/infra/resolver/auth/AuthArgumentResolver.java
+++ b/src/main/java/project/doblog/infra/resolver/auth/AuthArgumentResolver.java
@@ -1,0 +1,38 @@
+package project.doblog.infra.resolver.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import project.doblog.exception.error.InvalidTokenException;
+import project.doblog.infra.security.oauth.KakaoUserDetails;
+
+@Component
+@RequiredArgsConstructor
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Auth.class) && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null) {
+            throw new InvalidTokenException();
+        }
+
+        return ((KakaoUserDetails) authentication.getPrincipal()).getId();
+    }
+}

--- a/src/main/java/project/doblog/infra/resolver/refresh/RefreshToken.java
+++ b/src/main/java/project/doblog/infra/resolver/refresh/RefreshToken.java
@@ -1,0 +1,14 @@
+package project.doblog.infra.resolver.refresh;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * RefreshToken 추출 어노테이션
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RefreshToken {
+}

--- a/src/main/java/project/doblog/infra/resolver/refresh/RefreshTokenArgumentResolver.java
+++ b/src/main/java/project/doblog/infra/resolver/refresh/RefreshTokenArgumentResolver.java
@@ -1,0 +1,40 @@
+package project.doblog.infra.resolver.refresh;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import project.doblog.exception.error.InvalidTokenException;
+import project.doblog.utils.CookieUtils;
+
+import java.util.Objects;
+
+@Slf4j
+@Component
+public class RefreshTokenArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(RefreshToken.class) && parameter.getParameterType()
+                .equals(String.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        Cookie cookie = CookieUtils.getToken(
+                        Objects.requireNonNull(webRequest.getNativeRequest(HttpServletRequest.class)))
+                .orElseThrow(InvalidTokenException::new);
+
+        log.info("Cookie RefreshToken: {}", cookie.getValue());
+
+        return cookie.getValue();
+    }
+}

--- a/src/main/java/project/doblog/infra/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/project/doblog/infra/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,51 @@
+package project.doblog.infra.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import project.doblog.exception.ErrorResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        log.warn("JwtAccessDeniedHandler | 허용되지 않은 요청입니다.");
+
+        String json = objectMapper.writeValueAsString(ErrorResponse.builder()
+                .code(String.valueOf(HttpStatus.UNAUTHORIZED.value()))
+                .message("허용되지 않은 사용자 입니다.")
+                .build());
+
+        setResponseProperties(response);
+        writeJsonToResponse(response, json);
+    }
+
+    private void setResponseProperties(HttpServletResponse response) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    private void writeJsonToResponse(HttpServletResponse response, String json) throws IOException {
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/project/doblog/infra/security/jwt/JwtAuthenticationFailEntryPoint.java
+++ b/src/main/java/project/doblog/infra/security/jwt/JwtAuthenticationFailEntryPoint.java
@@ -1,0 +1,55 @@
+package project.doblog.infra.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import project.doblog.exception.ErrorResponse;
+import project.doblog.utils.ServletUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFailEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+
+        String accessToken = ServletUtils.findAuthorizationHeaderToRequest();
+
+        log.info("JwtAuthenticationFailEntryPoint | accessToken: {}", accessToken);
+        log.warn("JwtAuthenticationFailEntryPoint | 인증되지 않은 요청입니다.");
+
+        String json = objectMapper.writeValueAsString(ErrorResponse.builder()
+                .code(String.valueOf(HttpStatus.UNAUTHORIZED.value()))
+                .message("인증되지 않은 사용자 입니다.")
+                .build());
+
+        setResponseProperties(response);
+        writeJsonToResponse(response, json);
+    }
+
+    private void setResponseProperties(HttpServletResponse response) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    private void writeJsonToResponse(HttpServletResponse response, String json) throws IOException {
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/project/doblog/infra/security/jwt/JwtFilter.java
+++ b/src/main/java/project/doblog/infra/security/jwt/JwtFilter.java
@@ -1,0 +1,56 @@
+package project.doblog.infra.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import project.doblog.infra.security.jwt.token.TokenProvider;
+import project.doblog.utils.ServletUtils;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        log.info("URI = {}", request.getRequestURI());
+
+        String bearerToken = ServletUtils.findAuthorizationHeaderToRequest();
+
+        if (isNull(bearerToken) || !isValid(bearerToken)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Authentication authentication = tokenProvider.getAuthentication(removeBearer(bearerToken));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isNull(String bearerToken) {
+        return bearerToken == null;
+    }
+
+    private boolean isValid(String bearerToken) {
+        return tokenProvider.isValid(bearerToken);
+    }
+
+    private String removeBearer(String bearerToken) {
+        return bearerToken.replace("Bearer ", "");
+    }
+}

--- a/src/main/java/project/doblog/infra/security/jwt/token/RefreshToken.java
+++ b/src/main/java/project/doblog/infra/security/jwt/token/RefreshToken.java
@@ -1,0 +1,31 @@
+package project.doblog.infra.security.jwt.token;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+
+@Builder
+@Getter
+@RedisHash(value = "refresh", timeToLive = 604800)
+public class RefreshToken {
+
+    private Long id;
+    private String email;
+    private Collection<? extends GrantedAuthority> authorities;
+
+    @Indexed
+    private String refreshToken;
+
+    public String getAuthority() {
+        return authorities.stream()
+                .map(authority -> new SimpleGrantedAuthority(authority.getAuthority()))
+                .toList()
+                .get(0)
+                .getAuthority();
+    }
+}

--- a/src/main/java/project/doblog/infra/security/jwt/token/TokenProvider.java
+++ b/src/main/java/project/doblog/infra/security/jwt/token/TokenProvider.java
@@ -1,0 +1,119 @@
+package project.doblog.infra.security.jwt.token;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import project.doblog.infra.security.oauth.KakaoUserDetails;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class TokenProvider {
+
+    private static final String AUTH_ID = "ID";
+    private static final String AUTH_ROLE = "AUTHORITY";
+    private static final String AUTH_EMAIL = "EMAIL";
+    private Key key;
+    private final String secretKey;
+    private final long accessExpirations;
+    private final long refreshExpirations;
+
+    public TokenProvider(@Value("${jwt.secret_key}") String secretKey,
+                         @Value("${jwt.access_expirations}") long accessExpirations,
+                         @Value("${jwt.refresh_expirations}") long refreshExpirations) {
+        this.secretKey = secretKey;
+        this.accessExpirations = accessExpirations * 1000;
+        this.refreshExpirations = refreshExpirations * 1000;
+    }
+
+    @PostConstruct
+    public void initKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = new SecretKeySpec(keyBytes, "HmacSHA256");
+    }
+
+    public TokenResponse createToken(String userId, String email, String role) {
+        long now = (new Date()).getTime();
+
+        Date accessValidity = new Date(now + this.accessExpirations);
+        Date refreshValidity = new Date(now + this.refreshExpirations);
+
+        String accessToken = Jwts.builder()
+                .addClaims(Map.of(AUTH_ID, userId))
+                .addClaims(Map.of(AUTH_EMAIL, email))
+                .addClaims(Map.of(AUTH_ROLE, role))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .setExpiration(accessValidity)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .addClaims(Map.of(AUTH_ID, userId))
+                .addClaims(Map.of(AUTH_EMAIL, email))
+                .addClaims(Map.of(AUTH_ROLE, role))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .setExpiration(refreshValidity)
+                .compact();
+
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        List<String> authorities = Arrays.asList(claims.get(AUTH_ROLE)
+                .toString()
+                .split(","));
+
+        List<? extends GrantedAuthority> simpleGrantedAuthorities = authorities.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        KakaoUserDetails principal = new KakaoUserDetails(Long.parseLong((String) claims.get(AUTH_ID)),
+                (String) claims.get(AUTH_EMAIL),
+                simpleGrantedAuthorities, Map.of());
+
+        return new UsernamePasswordAuthenticationToken(principal, token, simpleGrantedAuthorities);
+    }
+
+    public boolean isValid(String token) {
+        return isBearerToken(token) && isValidToken(removeBearer(token));
+    }
+
+    private boolean isValidToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SignatureException | MalformedJwtException | ExpiredJwtException e) {
+            return false;
+        }
+    }
+
+    private boolean isBearerToken(String token) {
+        return token.startsWith("Bearer ");
+    }
+
+    private String removeBearer(String token) {
+        return token.replace("Bearer ", "");
+    }
+}

--- a/src/main/java/project/doblog/infra/security/jwt/token/TokenResponse.java
+++ b/src/main/java/project/doblog/infra/security/jwt/token/TokenResponse.java
@@ -1,0 +1,16 @@
+package project.doblog.infra.security.jwt.token;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenResponse {
+
+    private final String accessToken;
+    private final String refreshToken;
+
+    public static TokenResponse of(final String accessToken, final String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/project/doblog/infra/security/oauth/KakaoUserDetails.java
+++ b/src/main/java/project/doblog/infra/security/oauth/KakaoUserDetails.java
@@ -1,0 +1,35 @@
+package project.doblog.infra.security.oauth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+public class KakaoUserDetails implements OAuth2User {
+
+    private final Long id;
+    private final String email;
+    private final List<? extends GrantedAuthority> authorities;
+    private final Map<String, Object> attributes;
+
+    @Override
+    public String getName() {
+        return email;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+}

--- a/src/main/java/project/doblog/infra/security/oauth/KakaoUserDetailsService.java
+++ b/src/main/java/project/doblog/infra/security/oauth/KakaoUserDetailsService.java
@@ -1,0 +1,40 @@
+package project.doblog.infra.security.oauth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import project.doblog.domain.user.User;
+import project.doblog.domain.user.repository.UserRepository;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoUserDetailsService extends DefaultOAuth2UserService {
+
+    private static final String PREFIX = "낯선 ";
+    private static final String DEFAULT_ROLE = "USER";
+
+    private final UserRepository userRepository;
+
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+        String email = kakaoUserInfo.getEmail();
+
+        User user = userRepository.findByEmail(email)
+                .orElseGet(() -> userRepository.save(
+                        User.createUser(email, PREFIX + email.split("@")[0], null)
+                ));
+
+        log.info("카카오 유저 = {}", user);
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority(DEFAULT_ROLE);
+
+        return new KakaoUserDetails(user.getId(), email, List.of(authority), oAuth2User.getAttributes());
+    }
+}

--- a/src/main/java/project/doblog/infra/security/oauth/KakaoUserInfo.java
+++ b/src/main/java/project/doblog/infra/security/oauth/KakaoUserInfo.java
@@ -1,0 +1,29 @@
+package project.doblog.infra.security.oauth;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+public class KakaoUserInfo {
+
+    public static final String KAKAO_ACCOUNT = "kakao_account";
+    public static final String EMAIL = "email";
+
+    private Map<String, Object> attributes;
+
+    public KakaoUserInfo(final Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public String getEmail() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        TypeReference<Map<String, Object>> typeReferencer = new TypeReference<>() {
+        };
+
+        Object kakaoAccount = attributes.get(KAKAO_ACCOUNT);
+        Map<String, Object> account = objectMapper.convertValue(kakaoAccount, typeReferencer);
+
+        return (String) account.get(EMAIL);
+    }
+}

--- a/src/main/java/project/doblog/utils/CookieUtils.java
+++ b/src/main/java/project/doblog/utils/CookieUtils.java
@@ -1,0 +1,90 @@
+package project.doblog.utils;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    private static final int TOKEN_MAX_AGE = 604800;
+    private static final String TOKEN_NAME = "Authorization-refresh";
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(name))
+                .findFirst();
+    }
+
+    public static Optional<Cookie> getToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getCookies()).stream()
+                .flatMap(Arrays::stream)
+                .filter(cookie -> cookie.getName().equals(TOKEN_NAME))
+                .findFirst();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .path("/")
+                .maxAge(maxAge)
+                .secure(true)
+                .sameSite("None")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public static void addToken(HttpServletResponse response, String token) {
+        ResponseCookie cookie = ResponseCookie.from(TOKEN_NAME, token)
+                .path("/")
+                .maxAge(TOKEN_MAX_AGE)
+                .secure(true)
+                .sameSite("None")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(name))
+                .forEach(cookie -> {
+                    ResponseCookie responseCookie = ResponseCookie.from(cookie.getName(), cookie.getValue())
+                            .value("")
+                            .path("/")
+                            .secure(true)
+                            .maxAge(0)
+                            .build();
+
+                    response.addHeader("Set-Cookie", responseCookie.toString());
+                });
+    }
+
+    public static void deleteToken(HttpServletRequest request, HttpServletResponse response) {
+        Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(TOKEN_NAME))
+                .forEach(cookie -> {
+                    ResponseCookie responseCookie = ResponseCookie.from(cookie.getName())
+                            .value("")
+                            .path("/")
+                            .secure(true)
+                            .maxAge(0)
+                            .build();
+
+                    response.addHeader("Set-Cookie", responseCookie.toString());
+                });
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/main/java/project/doblog/utils/ServletUtils.java
+++ b/src/main/java/project/doblog/utils/ServletUtils.java
@@ -1,0 +1,53 @@
+package project.doblog.utils;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class ServletUtils {
+
+    public static String findAuthorizationHeaderToRequest() {
+        HttpServletRequest request = findServletRequest();
+        return request.getHeader("Authorization");
+    }
+
+    public static String findAuthorizationRefreshHeaderToRequest() {
+        HttpServletRequest request = findServletRequest();
+        return request.getHeader("Authorization-refresh");
+    }
+
+    public static void addAuthorizationHeaderToResponse(String token) {
+        HttpServletResponse response = findServletResponse();
+        response.addHeader("Authorization", "Bearer " + token);
+    }
+
+    public static void addAuthorizationRefreshHeaderToResponse(String token) {
+        HttpServletResponse response = findServletResponse();
+        response.addHeader("Authorization-refresh", token);
+    }
+
+    public static void addRefreshTokenCookieToResponse(String token) {
+        HttpServletResponse response = findServletResponse();
+        CookieUtils.addToken(response, token);
+    }
+
+    public static void deleteRefreshTokenCookieToResponse() {
+        HttpServletRequest request = findServletRequest();
+        HttpServletResponse response = findServletResponse();
+
+        CookieUtils.deleteToken(request, response);
+    }
+
+    private static HttpServletRequest findServletRequest() {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        return (HttpServletRequest) requestAttributes.resolveReference(RequestAttributes.REFERENCE_REQUEST);
+    }
+
+    private static HttpServletResponse findServletResponse() {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+
+        return ((ServletRequestAttributes) requestAttributes).getResponse();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,28 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  h2:
+    console:
+      enabled: true
+
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/doblog
+    username: sa
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        show_sql: true
+        format_sql: true
+    defer-datasource-initialization: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: password

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=doblog

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  profiles:
+    active:
+      dev
+    group:
+      local-env:
+        - local
+      dev-env:
+        - dev
+      prod-env:
+        - prod
+    include:
+      - jwt
+      - oauth


### PR DESCRIPTION
## 💡 연관된 이슈
close #1 

## 📝 작업 내용
- 카카오 로그인 API, 토큰 Reissue API 추가
- 사용자 인증 정보 추출 어노테이션 `@Auth` 추가
- RefreshToken 추출 어노테이션 `@RefreshToken` 추가